### PR TITLE
set disgord to v0.11 + middleware and logger logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,5 @@ module gitea.pi.lan/dustin/BasicDiscordBot
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/andersfylling/disgord v0.10.3
+	github.com/andersfylling/disgord v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,11 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/andersfylling/disgord v0.10.3 h1:A8qiKrDBisIJqi8+pKnxT1UGkr/Gz/B8fQlti3KJBFQ=
-github.com/andersfylling/disgord v0.10.3/go.mod h1:FEs5iLChQBxayI8Wi3Ul2H5j6zar5LnfqfHAanQ6gMg=
+github.com/andersfylling/disgord v0.11.0 h1:Eh7QH0fb1bygKhTupuj92R3Wp0dDf/NLryJVVWDIX0c=
+github.com/andersfylling/disgord v0.11.0/go.mod h1:2NX6S/GJIyR5HZKYzJLPEyLLpZFb6GoGlkf0sW/ofBE=
 github.com/andersfylling/snowflake/v3 v3.0.2 h1:4G4da8UizMuqH0bGr5kEv+6CFFANldUi8GBdpw0PvLg=
 github.com/andersfylling/snowflake/v3 v3.0.2/go.mod h1:wppPwIA+SDLR5F21VoW2ir06w8GtB2ZAOCuq7xjGOF0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -16,9 +17,12 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
Hey, great to see you're using DisGord!
Discord is doing a breaking change so I'm going around to the few open source projects on GitHub and letting them know about this. So I highly suggest upgrading to v0.11 or v0.10.4.

Just for fun I added a middleware for your prefix and a logger for your terminal printout. Hope those are interesting for you even if you don't merge this. It's just a friendly notification that any disgord version below v0.10.4 and v0.11 will cease to work with the discord API in less than a month.

Source: https://github.com/discordapp/discord-api-docs/pull/967